### PR TITLE
Update for zig 0.12.0-dev.2727+fad5e7a99 (2024-02-13) 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,13 +22,6 @@ jobs:
         run: zig build test
         working-directory: zini
 
-      ## Now try to build the executables:
-      - name: Checkout parg
-        uses: actions/checkout@v3
-        with:
-          repository: judofyr/parg
-          path: parg
-
       - name: Build executables
         run: zig build
         working-directory: zini

--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@ The Bumped Ribbon Retrieval will often have **less than 1% overhead**.
 Zini is intended to be used as a library, but also ships the command-line tools `zini-pthash` and `zini-ribbon`.
 As the documentation is a bit lacking it might be useful to look through `tools/zini-{pthash,ribbon}/main.zig` to understand how it's used.
 
-Note that building these executables depends on having [parg](https://github.com/judofyr/parg) cloned in `../parg`.
-You may want to tweak this in `build.zig`.
-
 ```
 USAGE
   ./zig-out/bin/zini-pthash [build | lookup] <options>

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub fn build(b: *std.Build) void {
+pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
@@ -18,12 +18,17 @@ pub fn build(b: *std.Build) void {
 
     const coverage = b.option(bool, "test-coverage", "Generate test coverage") orelse false;
     if (coverage) {
-        tests_run_step.addArgs(&.{
+        const runner = [_][]const u8{
             "kcov",
             "--include-path",
             ".",
             "coverage", // output dir
-        });
+        };
+
+        const dst = try tests_run_step.argv.addManyAt(0, runner.len);
+        for (runner, 0..) |arg, idx| {
+            dst[idx] = .{ .bytes = b.dupe(arg) };
+        }
     }
 
     const test_step = b.step("test", "Run unit tests");

--- a/build.zig
+++ b/build.zig
@@ -1,11 +1,11 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
     const zini = b.addModule("zini", .{
-        .source_file = .{ .path = "src/main.zig" },
+        .root_source_file = .{ .path = "src/main.zig" },
     });
 
     const tests = b.addTest(.{
@@ -29,7 +29,7 @@ pub fn build(b: *std.build.Builder) void {
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&tests_run_step.step);
 
-    const parg = b.createModule(.{ .source_file = .{
+    const parg = b.createModule(.{ .root_source_file = .{
         .path = "../parg/src/parser.zig",
     } });
 
@@ -39,8 +39,8 @@ pub fn build(b: *std.build.Builder) void {
         .target = target,
         .optimize = optimize,
     });
-    pthash.addModule("zini", zini);
-    pthash.addModule("parg", parg);
+    pthash.root_module.addImport("zini", zini);
+    pthash.root_module.addImport("parg", parg);
     b.installArtifact(pthash);
 
     const ribbon = b.addExecutable(.{
@@ -49,7 +49,7 @@ pub fn build(b: *std.build.Builder) void {
         .target = target,
         .optimize = optimize,
     });
-    ribbon.addModule("zini", zini);
-    ribbon.addModule("parg", parg);
+    ribbon.root_module.addImport("zini", zini);
+    ribbon.root_module.addImport("parg", parg);
     b.installArtifact(ribbon);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,62 @@
+.{
+    .name = "zini",
+    // This is a [Semantic Version](https://semver.org/).
+    // In a future version of Zig it will be used for package deduplication.
+    .version = "0.0.0",
+
+    // This field is optional.
+    // This is currently advisory only; Zig does not yet do anything
+    // with this value.
+    //.minimum_zig_version = "0.11.0",
+
+    // This field is optional.
+    // Each dependency must either provide a `url` and `hash`, or a `path`.
+    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
+    // Once all dependencies are fetched, `zig build` no longer requires
+    // internet connectivity.
+    .dependencies = .{
+        // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
+        .parg = .{
+            // When updating this field to a new URL, be sure to delete the corresponding
+            // `hash`, otherwise you are communicating that you expect to find the old hash at
+            // the new URL.
+            .url = "https://github.com/malcolmstill/parg/archive/677c86dc48d88042f5d8e02d8b86839bfe82c5f6.tar.gz",
+
+            // This is computed from the file contents of the directory of files that is
+            // obtained after fetching `url` and applying the inclusion rules given by
+            // `paths`.
+            //
+            // This field is the source of truth; packages do not come from a `url`; they
+            // come from a `hash`. `url` is just one of many possible mirrors for how to
+            // obtain a package matching this `hash`.
+            //
+            // Uses the [multihash](https://multiformats.io/multihash/) format.
+            .hash = "1220bb37738c99ec46f6d0f2692cf47a4fca3b07603ba40f605ff05ac824c9008d23",
+
+            // When this is provided, the package is found in a directory relative to the
+            // build root. In this case the package's hash is irrelevant and therefore not
+            // computed. This field and `url` are mutually exclusive.
+            // .path = "foo",
+        },
+    },
+
+    // Specifies the set of files and directories that are included in this package.
+    // Only files and directories listed here are included in the `hash` that
+    // is computed for this package.
+    // Paths are relative to the build root. Use the empty string (`""`) to refer to
+    // the build root itself.
+    // A directory listed here means that all files within, recursively, are included.
+    .paths = .{
+        // This makes *all* files, recursively, included in this package. It is generally
+        // better to explicitly list the files and directories instead, to insure that
+        // fetching from tarballs, file system paths, and version control all result
+        // in the same contents hash.
+        "",
+        // For example...
+        //"build.zig",
+        //"build.zig.zon",
+        //"src",
+        //"LICENSE",
+        //"README.md",
+    },
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -20,7 +20,7 @@
             // When updating this field to a new URL, be sure to delete the corresponding
             // `hash`, otherwise you are communicating that you expect to find the old hash at
             // the new URL.
-            .url = "https://github.com/malcolmstill/parg/archive/677c86dc48d88042f5d8e02d8b86839bfe82c5f6.tar.gz",
+            .url = "https://github.com/judofyr/parg/archive/25775b72143e00b2b69a372ffbc8ee10f97d0e12.tar.gz",
 
             // This is computed from the file contents of the directory of files that is
             // obtained after fetching `url` and applying the inclusion rules given by

--- a/src/DictArray.zig
+++ b/src/DictArray.zig
@@ -34,7 +34,7 @@ pub fn encode(allocator: std.mem.Allocator, data: []const u64) !Self {
     defer mapping.deinit();
 
     for (data) |val| {
-        var result = try mapping.getOrPut(val);
+        const result = try mapping.getOrPut(val);
         if (!result.found_existing) {
             result.value_ptr.* = dict.items.len;
             try dict.append(val);

--- a/src/EliasFano.zig
+++ b/src/EliasFano.zig
@@ -72,10 +72,10 @@ pub fn writeTo(self: *const Self, w: anytype) !void {
 }
 
 pub fn readFrom(stream: *std.io.FixedBufferStream([]const u8)) !Self {
-    var mask_arr = try utils.readSlice(stream, usize);
-    var high_bits = DynamicBitSetUnmanaged{ .masks = @constCast(mask_arr.ptr) + 1 };
-    var high_bits_select = try DArray1.readFrom(stream);
-    var low_bits = try CompactArray.readFrom(stream);
+    const mask_arr = try utils.readSlice(stream, usize);
+    const high_bits = DynamicBitSetUnmanaged{ .masks = @constCast(mask_arr.ptr) + 1 };
+    const high_bits_select = try DArray1.readFrom(stream);
+    const low_bits = try CompactArray.readFrom(stream);
     return Self{
         .high_bits = high_bits,
         .high_bits_select = high_bits_select,

--- a/src/darray.zig
+++ b/src/darray.zig
@@ -78,8 +78,8 @@ pub fn DArray(comptime val: bool) type {
             subblock_inventory: *std.ArrayListUnmanaged(u16),
             overflow_positions: *std.ArrayListUnmanaged(u64),
         ) !void {
-            var fst = cur_block_positions.items[0];
-            var lst = cur_block_positions.items[cur_block_positions.items.len - 1];
+            const fst = cur_block_positions.items[0];
+            const lst = cur_block_positions.items[cur_block_positions.items.len - 1];
             if (lst - fst < max_in_block_distance) {
                 try block_inventory.append(allocator, BlockPosition{ .is_overflow = false, .pos = fst });
                 var i: usize = 0;
@@ -87,7 +87,7 @@ pub fn DArray(comptime val: bool) type {
                     try subblock_inventory.append(allocator, @intCast(cur_block_positions.items[i] - fst));
                 }
             } else {
-                var overflow_pos = overflow_positions.items.len;
+                const overflow_pos = overflow_positions.items.len;
                 try block_inventory.append(allocator, BlockPosition{ .is_overflow = true, .pos = @intCast(overflow_pos) });
                 for (cur_block_positions.items) |pos| {
                     try overflow_positions.append(allocator, pos);
@@ -130,7 +130,7 @@ pub fn DArray(comptime val: bool) type {
             word &= @as(u64, @bitCast(@as(i64, -1))) << word_shift;
 
             while (true) {
-                var popcount = @popCount(word);
+                const popcount = @popCount(word);
                 if (reminder < popcount) break;
                 reminder -= popcount;
                 word_idx += 1;
@@ -166,9 +166,9 @@ pub fn DArray(comptime val: bool) type {
         }
 
         pub fn readFrom(stream: *std.io.FixedBufferStream([]const u8)) !Self {
-            var block_inventory = try utils.readSlice(stream, BlockPosition);
-            var subblock_inventory = try utils.readSlice(stream, u16);
-            var overflow_positions = try utils.readSlice(stream, u64);
+            const block_inventory = try utils.readSlice(stream, BlockPosition);
+            const subblock_inventory = try utils.readSlice(stream, u16);
+            const overflow_positions = try utils.readSlice(stream, u64);
             return Self{
                 .block_inventory = @constCast(block_inventory),
                 .subblock_inventory = @constCast(subblock_inventory),

--- a/src/ribbon.zig
+++ b/src/ribbon.zig
@@ -770,8 +770,9 @@ pub fn RibbonAutoHash(comptime Key: type) type {
 
 const testing = std.testing;
 const Wyhash = std.hash.Wyhash;
+const TestErrorSet = error{ OutOfMemory, HashCollision, TestExpectedEqual };
 
-fn testRibbon(t: anytype) anyerror!void {
+fn testRibbon(t: anytype) TestErrorSet!void {
     const valueSize = 8;
     t.setValueSize(valueSize);
     t.setBandWidth(32);
@@ -941,19 +942,19 @@ const BumpedRibbonTest = struct {
     }
 };
 
-fn testRibbonIncremental(allocator: std.mem.Allocator) anyerror!void {
+fn testRibbonIncremental(allocator: std.mem.Allocator) TestErrorSet!void {
     var t = RibbonIncrementalTest{ .allocator = allocator, .n = 100 };
     defer t.deinit();
     try testRibbon(&t);
 }
 
-fn testRibbonIterative(allocator: std.mem.Allocator) anyerror!void {
+fn testRibbonIterative(allocator: std.mem.Allocator) TestErrorSet!void {
     var t = RibbonIterativeTest{ .allocator = allocator, .n = 100 };
     defer t.deinit();
     try testRibbon(&t);
 }
 
-fn testBumpedRibbon(allocator: std.mem.Allocator) anyerror!void {
+fn testBumpedRibbon(allocator: std.mem.Allocator) TestErrorSet!void {
     var t = BumpedRibbonTest{ .allocator = allocator, .n = 100 };
     defer t.deinit();
     try testRibbon(&t);

--- a/src/ribbon.zig
+++ b/src/ribbon.zig
@@ -771,7 +771,7 @@ pub fn RibbonAutoHash(comptime Key: type) type {
 const testing = std.testing;
 const Wyhash = std.hash.Wyhash;
 
-fn testRibbon(t: anytype) !void {
+fn testRibbon(t: anytype) anyerror!void {
     const valueSize = 8;
     t.setValueSize(valueSize);
     t.setBandWidth(32);
@@ -941,19 +941,19 @@ const BumpedRibbonTest = struct {
     }
 };
 
-fn testRibbonIncremental(allocator: std.mem.Allocator) !void {
+fn testRibbonIncremental(allocator: std.mem.Allocator) anyerror!void {
     var t = RibbonIncrementalTest{ .allocator = allocator, .n = 100 };
     defer t.deinit();
     try testRibbon(&t);
 }
 
-fn testRibbonIterative(allocator: std.mem.Allocator) !void {
+fn testRibbonIterative(allocator: std.mem.Allocator) anyerror!void {
     var t = RibbonIterativeTest{ .allocator = allocator, .n = 100 };
     defer t.deinit();
     try testRibbon(&t);
 }
 
-fn testBumpedRibbon(allocator: std.mem.Allocator) !void {
+fn testBumpedRibbon(allocator: std.mem.Allocator) anyerror!void {
     var t = BumpedRibbonTest{ .allocator = allocator, .n = 100 };
     defer t.deinit();
     try testRibbon(&t);

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,8 +1,10 @@
 const std = @import("std");
+const builtin = @import("builtin");
+const endian = builtin.cpu.arch.endian();
 
 pub fn writeSlice(w: anytype, arr: anytype) !void {
     const T = @TypeOf(arr[0]);
-    try w.writeIntNative(u64, arr.len);
+    try w.writeInt(u64, arr.len, endian);
     const byte_len = arr.len * @sizeOf(T);
     if (byte_len == 0) return;
     try w.writeAll(@as([*]const u8, @ptrCast(&arr[0]))[0..byte_len]);
@@ -12,7 +14,7 @@ pub fn writeSlice(w: anytype, arr: anytype) !void {
 
 pub fn readSlice(stream: *std.io.FixedBufferStream([]const u8), T: anytype) ![]const T {
     var r = stream.reader();
-    var len = try r.readIntNative(u64);
+    const len = try r.readInt(u64, endian);
     const byte_len = len * @sizeOf(T);
     if (byte_len == 0) return &[_]T{};
     const data = stream.buffer[stream.pos..][0..byte_len];

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -31,7 +31,7 @@ pub fn bitSizeOfSlice(arr: anytype) u64 {
 pub fn autoHash(comptime Key: type) fn (seed: u64, key: Key) u64 {
     return struct {
         fn hash(seed: u64, key: Key) u64 {
-            if (comptime std.meta.trait.hasUniqueRepresentation(Key)) {
+            if (comptime std.meta.hasUniqueRepresentation(Key)) {
                 return std.hash.Wyhash.hash(seed, std.mem.asBytes(&key));
             } else {
                 var hasher = std.hash.Wyhash.init(seed);
@@ -45,7 +45,7 @@ pub fn autoHash(comptime Key: type) fn (seed: u64, key: Key) u64 {
 pub fn testFailingAllocator(comptime t: fn (allocator: std.mem.Allocator) anyerror!void) !void {
     var idx: usize = 0;
     while (true) : (idx += 1) {
-        var failing_alloc = std.testing.FailingAllocator.init(std.testing.allocator, idx);
+        var failing_alloc = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = idx });
 
         try (t(failing_alloc.allocator()) catch |err| switch (err) {
             error.OutOfMemory => continue,

--- a/tools/zini-pthash/main.zig
+++ b/tools/zini-pthash/main.zig
@@ -136,7 +136,7 @@ pub fn build(allocator: std.mem.Allocator, p: anytype) !void {
     var file = try std.fs.cwd().openFile(input.?, .{});
     defer file.close();
 
-    var data = try file.reader().readAllAlloc(allocator, 10 * 1024 * 1024);
+    const data = try file.reader().readAllAlloc(allocator, 10 * 1024 * 1024);
     defer allocator.free(data);
 
     var keys = std.ArrayList([]const u8).init(allocator);
@@ -250,7 +250,7 @@ pub fn lookup(allocator: std.mem.Allocator, p: anytype) !void {
 
     if (key) |k| {
         std.debug.print("Looking up key={s}:\n", .{k});
-        var h = hash.get(k);
+        const h = hash.get(k);
         try stdout.print("{}\n", .{h});
         if (dict) |d| {
             try stdout.print("{s}\n", .{d.get(arr.?.get(h))});


### PR DESCRIPTION
# Description

Updates for zig `0.12.0-dev.2727+fad5e7a99` (2024-02-13), namely:
- Recent zig requires `const` where variables are not modified
- `readIntNative` / `writeIntNative` no longer exist, instead we use `readInt` / `writeInt` and pass in an endianness
- Changes to `build.zig`:
    - `source_file` -> `root_source_file` in `addModule`
    - a separate `addModule` no longer exists, instead I think we have to `.root_module.addImport` (my reference for this is https://ziggit.dev/t/what-happened-to-addmodule/2908)

Additionally, this PR changes the `parg` dependency to be installed via `build.zig.zon` rather than via an assumed relative path:
- I have generated a `build.zig.zon` from a fresh `zig init` (currently I have retained the surrounding comments, but can remove if so desired)
- ~Currently the `build.zig.zon` references my fork of `parg` (https://github.com/malcolmstill/parg) for testing. Once https://github.com/judofyr/parg/pull/2 is merged I will update `build.zig.zon` to reference the original repo and undraft this PR.~

Note: I'm not quite sure I have the `test-coverage` part of the `build.zig` correct at the moment.