### PR TITLE
Fix padding in `writeSlice`/ `readSlice`

### DIFF
--- a/src/utils.zig
+++ b/src/utils.zig
@@ -55,3 +55,20 @@ pub fn testFailingAllocator(comptime t: fn (allocator: std.mem.Allocator) anyerr
         return;
     }
 }
+
+const testing = std.testing;
+
+test "readSlice / writeSlice must maintain 8-byte alignment" {
+    var buf: [128]u8 = undefined;
+    var write_stream = std.io.fixedBufferStream(buf[0..]);
+
+    const writer = write_stream.writer();
+
+    try writeSlice(writer, [_]u8{ 1, 2, 3 });
+    try writeSlice(writer, [_]u64{2});
+
+    var read_stream = std.io.fixedBufferStream(@as([]const u8, buf[0..]));
+
+    try testing.expectEqualSlices(u8, &.{ 1, 2, 3 }, try readSlice(&read_stream, u8));
+    try testing.expectEqualSlices(u64, &.{2}, try readSlice(&read_stream, u64));
+}

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -13,6 +13,10 @@ pub fn writeSlice(w: anytype, arr: anytype) !void {
 }
 
 pub fn readSlice(stream: *std.io.FixedBufferStream([]const u8), T: anytype) ![]const T {
+    // Invariant: stream.pos should be 8-byte aligned before and after `readSlice`
+    std.debug.assert(stream.pos % @alignOf(u64) == 0);
+    defer std.debug.assert(stream.pos % @alignOf(u64) == 0);
+
     var r = stream.reader();
     const len = try r.readInt(u64, endian);
     const byte_len = len * @sizeOf(T);

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -9,7 +9,8 @@ pub fn writeSlice(w: anytype, arr: anytype) !void {
     if (byte_len == 0) return;
     try w.writeAll(@as([*]const u8, @ptrCast(&arr[0]))[0..byte_len]);
     // Make sure we're always at a 64-bit boundary.
-    try w.writeByteNTimes(0, byte_len % @alignOf(u64));
+    const padding = (@alignOf(u64) - (byte_len % @alignOf(u64))) % @alignOf(u64);
+    try w.writeByteNTimes(0, padding);
 }
 
 pub fn readSlice(stream: *std.io.FixedBufferStream([]const u8), T: anytype) ![]const T {
@@ -23,7 +24,8 @@ pub fn readSlice(stream: *std.io.FixedBufferStream([]const u8), T: anytype) ![]c
     if (byte_len == 0) return &[_]T{};
     const data = stream.buffer[stream.pos..][0..byte_len];
     stream.pos += byte_len;
-    stream.pos += byte_len % @alignOf(u64);
+    const padding = (@alignOf(u64) - (byte_len % @alignOf(u64))) % @alignOf(u64);
+    stream.pos += padding;
     const cast_data: [*]const T = @ptrCast(@alignCast(&data[0]));
     return cast_data[0..len];
 }


### PR DESCRIPTION
# Description

Fixes #1 

In this PR the:
- first commit adds a test of `readSlice` / `writeSlice` that fails without the padding fix from the final commit
- second commit adds pre- and post-assertions that `stream.pos` is 8-byte aligned
- final commit fixes the padding issue.